### PR TITLE
Add BlackProtect details to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,20 @@ Arvoris is Papyrus's budget-focused Minecraft reverse proxy. It combines Cloudfl
 - Proximity & Voice plugins: No
 - Recommended: ⭐⭐
 
+##### [BlackProtect](https://blackprotect.net)
+
+BlackProtect is an eBPF/XDP kernel-level L3-L7 DDoS protection service built specifically for Minecraft infrastructure with sub-1ms latency overhead and native EU hosting.
+
+- [Website](https://blackprotect.net)
+- Locations: Germany (Frankfurt, Hamburg)
+- Pricing type: Subscription
+- Supports Bedrock (Geyser): Yes
+- Free plan: Yes (Pilot Access)
+- Cheapest paid plan: TBD / mo.
+- Anti VPN: Yes
+- Proximity & Voice plugins: Yes (PlasmoVoice & SimpleVoiceChat)
+- Recommended: ⭐⭐⭐⭐⭐
+
 ## Contact
 Leave a star and join our Discord if you've found this helpful!
 


### PR DESCRIPTION
Added information about BlackProtect DDoS protection service for Minecraft.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a BlackProtect subsection to the DDoS Protection Service documentation.
  - Described its kernel-level protection, low-latency performance, EU hosting locations, pricing plans, Bedrock compatibility, Anti-VPN support, voice chat support, and free pilot option.
  - Included the service website and a recommendation rating.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->